### PR TITLE
Fix missing auth middleware and user controller

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,0 +1,69 @@
+import { db, adminApp } from '../config/firebaseAdminInit.js';
+
+// Fetch all users (admin only)
+export async function getAllUsers(req, res) {
+  try {
+    const snapshot = await db.collection('users').get();
+    const users = snapshot.docs.map(doc => {
+      const { password, ...data } = doc.data();
+      return { id: doc.id, ...data };
+    });
+    res.status(200).json({ users });
+  } catch (error) {
+    console.error('Error fetching users:', error);
+    res.status(500).json({ message: 'Server error fetching users.' });
+  }
+}
+
+// Fetch a single user by ID (admin only)
+export async function getUserById(req, res) {
+  try {
+    const doc = await db.collection('users').doc(req.params.id).get();
+    if (!doc.exists) {
+      return res.status(404).json({ message: 'User not found.' });
+    }
+    const { password, ...data } = doc.data();
+    res.status(200).json({ id: doc.id, ...data });
+  } catch (error) {
+    console.error('Error fetching user:', error);
+    res.status(500).json({ message: 'Server error fetching user.' });
+  }
+}
+
+// Update a user document (admin only)
+export async function updateUser(req, res) {
+  try {
+    const updates = req.body;
+    const userRef = db.collection('users').doc(req.params.id);
+    const doc = await userRef.get();
+    if (!doc.exists) {
+      return res.status(404).json({ message: 'User not found.' });
+    }
+    await userRef.update({
+      ...updates,
+      updatedAt: adminApp.firestore.FieldValue.serverTimestamp(),
+    });
+    const updatedDoc = await userRef.get();
+    const { password, ...data } = updatedDoc.data();
+    res.status(200).json({ message: 'User updated successfully.', user: { id: updatedDoc.id, ...data } });
+  } catch (error) {
+    console.error('Error updating user:', error);
+    res.status(500).json({ message: 'Server error updating user.' });
+  }
+}
+
+// Delete a user document (admin only)
+export async function deleteUser(req, res) {
+  try {
+    const userRef = db.collection('users').doc(req.params.id);
+    const doc = await userRef.get();
+    if (!doc.exists) {
+      return res.status(404).json({ message: 'User not found.' });
+    }
+    await userRef.delete();
+    res.status(200).json({ message: 'User deleted successfully.' });
+  } catch (error) {
+    console.error('Error deleting user:', error);
+    res.status(500).json({ message: 'Server error deleting user.' });
+  }
+}

--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,0 +1,42 @@
+import jwt from 'jsonwebtoken';
+
+/**
+ * Verifies that a request contains a valid JWT in the Authorization header.
+ * If valid, the decoded payload is attached to `req.user`.
+ */
+export function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+
+  if (!token) {
+    return res.status(401).json({ message: 'Authentication token missing.' });
+  }
+
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) {
+      return res.status(403).json({ message: 'Invalid or expired token.' });
+    }
+    req.user = user;
+    next();
+  });
+}
+
+/**
+ * Ensures the authenticated user has admin privileges.
+ */
+export function checkAdmin(req, res, next) {
+  if (!req.user?.isAdmin) {
+    return res.status(403).json({ message: 'Admin privileges required.' });
+  }
+  next();
+}
+
+/**
+ * Ensures the authenticated user has accepted the NDA.
+ */
+export function checkNdaAccepted(req, res, next) {
+  if (!req.user?.isNDAAccepted) {
+    return res.status(403).json({ message: 'NDA must be accepted before accessing this resource.' });
+  }
+  next();
+}


### PR DESCRIPTION
## Summary
- add JWT-based auth middleware with admin and NDA checks
- implement Firestore-based user controller

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891450d34608329b2087628dc1bad70